### PR TITLE
Add TinyMCE editor component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "rollup-plugin-cleaner": "^1.0.0",
         "rollup-plugin-summary": "^1.4.3",
         "rollup-plugin-terser": "^7.0.2",
+        "tslib": "^2.4.0",
         "typescript": "^4.7.3"
       }
     },
@@ -3127,9 +3128,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -3146,6 +3147,12 @@
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5518,9 +5525,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "tsutils": {
@@ -5530,6 +5537,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "rollup-plugin-cleaner": "^1.0.0",
     "rollup-plugin-summary": "^1.4.3",
     "rollup-plugin-terser": "^7.0.2",
+    "tslib": "^2.4.0",
     "typescript": "^4.7.3"
   },
   "dependencies": {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
 export { default as ImageElement } from './image'
+export { default as TinyMceElement } from './tinymce'

--- a/src/components/tinymce/index.ts
+++ b/src/components/tinymce/index.ts
@@ -1,0 +1,115 @@
+import { LitElement, html } from 'lit'
+import { customElement, property } from 'lit/decorators.js'
+import { getService } from '../../base/angular'
+
+const $compile = getService('$compile')
+const $rootScope = getService('$rootScope')
+
+export enum EditingMode {
+  Classic = 'classic',
+  DistractionFree = 'distractoin-free'
+}
+
+@customElement('umbh-tinymce')
+export default class extends LitElement {
+  @property({ type: Number, attribute: 'max-image-size' })
+  get maxImageSize (): number { return this.#scope.model.config.editor.maxImageSize }
+
+  set maxImageSize (value: number) { this.#scope.model.config.editor.maxImageSize = value }
+
+  @property({ type: String })
+  get mode (): EditingMode { return this.#scope.model.config.editor.mode }
+
+  set mode (value: EditingMode) { this.#scope.model.config.editor.mode = value }
+
+  @property({ type: Array, attribute: false })
+  get stylesheets (): string[] { return this.#scope.model.config.editor.stylesheets }
+
+  set stylesheets (value: string[]) { this.#scope.model.config.editor.stylesheets = value }
+
+  @property({ type: Array, attribute: false })
+  get toolbar (): string[] { return this.#scope.model.config.editor.toolbar }
+
+  set toolbar (value: string[]) { this.#scope.model.config.editor.toolbar = value === undefined || value === null ? this.#defaultToolbar : value }
+
+  @property({ type: String })
+  get value (): string { return this.#scope.model.value }
+
+  set value (value: string) { this.#scope.model.value = value }
+
+  #dataTypeKey: string | undefined
+  #template = (scope: any) => {}
+  #scope: any = {}
+
+  #defaultToolbar = [
+    'ace',
+    'styleselect',
+    'bold',
+    'italic',
+    'alignleft',
+    'aligncenter',
+    'alignright',
+    'bullist',
+    'numlist',
+    'outdent',
+    'indent',
+    'link',
+    'unlink',
+    'umbmediapicker',
+    'umbembeddialog'
+  ]
+
+  constructor () {
+    super()
+
+    this.#scope = $rootScope.$new(true)
+
+    this.#scope.model = {
+      view: 'rte',
+      config: {
+        editor: {
+          mode: EditingMode.Classic,
+          stylesheets: [],
+          toolbar: this.#defaultToolbar
+        }
+      }
+    }
+
+    this.#scope.$watch('model.value', (newValue: string, oldValue: string) => {
+      const event = new InputEvent('input', { bubbles: true, composed: true })
+      this.dispatchEvent(event)
+    })
+  }
+
+  createRenderRoot (): HTMLElement { return this }
+
+  connectedCallback (): void {
+    super.connectedCallback()
+
+    // find the umb-property and fetch the dataTypeKey, this is required
+    // by some of the server api's to look up if start nodes should be ignored
+    // and we don't wan't to expose this as a property on this element since
+    // it's an implementation detail
+    const propertyElement = this.closest('umb-property')
+    if (propertyElement !== null) {
+      const propertyScope = window.angular.element(propertyElement)?.scope()
+      // @ts-expect-error
+      this.#scope.model.dataTypeKey = propertyScope?.property?.dataTypeKey
+    }
+
+    // unfortunately the normal rte and the grid rte are two different editors
+    // even though they are mostly the same the normal does not work inside
+    // the grid, so we need to detect if we are inside the grid and return
+    // the correct HTML. If we have a parent element with the css class .umb-grid
+    // we assume we are inside the grid
+    const inGrid = this.closest('.umb-grid')
+
+    this.#template = $compile((inGrid != null)
+      ? '<grid-rte value="model.value" datatype-key="{{ model.dataTypeKey }}" configuration="model.config.editor"></grid-rte>'
+      : '<ng-form><umb-property-editor model="model"></umb-property-editor></ng-form>')
+  }
+
+  render (): any {
+    return html`${this.#template(this.#scope)}`
+  }
+}


### PR DESCRIPTION
Adds a custom element `<umbh-tinymce>` wrapping Umbraco's AngularJS implementation of TinyMCE.

The element supports both being used in the grid and as a property editor (only tested inside the grid)

A custom grid editor using LitElements and the editor could look something like this:

```typescript
export default class extends LitElement {
  static properties = {
    value: { type: String }
  }

  // define available toolbar options
  #toolbar = [
    'ace',
    'styleselect',
    'bold',
    'italic',
    'alignleft',
    'aligncenter',
    'alignright',
    'bullist',
    'numlist',
    'outdent',
    'indent',
    'link',
    'unlink'
  ]

  // load custom stylesheets created through the Backoffice
  // note the entries are the name of the stylesheet without .css
  #stylesheets = ['rte']

  // don't attach to Shadow DOM
  createRenderRoot() { return this }

  render() {
    return html`<umbh-tinymce mode="classic" max-image-size="500" .stylesheets=${this.#stylesheets} .toolbar=${this.#toolbar} .value=${this.value} @input=${e => this.value = e.target.value}></umbh-tinymce>`
  }
}
```

**NOTE: Since we are wrapping an AngularJS component, the `umbh-tinymce` component cannot be used inside Shadow DOM**