### PR TITLE
Add content picker bridge

### DIFF
--- a/src/base/angular/index.ts
+++ b/src/base/angular/index.ts
@@ -5,6 +5,7 @@ const injector = window.angular?.element(document.body)?.injector()
 export interface EditorService {
   close: Function
   mediaPicker: Function
+  contentPicker: Function
 }
 
 export const getService: any = (service: string) => injector.get(service)
@@ -12,5 +13,6 @@ export const editorService: EditorService = injector !== undefined
   ? getService('editorService')
   : {
       close: () => {},
+      contentPicker: () => {},
       mediaPicker: () => {}
     }

--- a/src/pickers/content/index.ts
+++ b/src/pickers/content/index.ts
@@ -1,0 +1,30 @@
+import { Udi } from '../../types'
+import { editorService } from '../../base/angular'
+
+export interface ContentPickerItem {
+  udi: String
+}
+
+export interface ContentPickerConfig {
+  startNode: Udi | undefined
+  multiple: Boolean | undefined
+  submit: (items: ContentPickerItem[]) => void
+}
+
+export default {
+  show: (config: ContentPickerConfig): void => {
+    editorService.contentPicker({
+      startNodeId: config.startNode,
+      multiPicker: config.multiple,
+      close: () => {
+        editorService.close()
+      },
+      submit: (model: any) => {
+        editorService.close()
+        config.submit(model.selection.map((item: any) => ({
+          udi: item.udi
+        })))
+      }
+    })
+  }
+}

--- a/src/pickers/index.ts
+++ b/src/pickers/index.ts
@@ -1,1 +1,2 @@
+export { default as contentPicker, ContentPickerConfig, ContentPickerItem } from './content'
 export { default as mediaPicker, MediaPickerConfig, MediaPickerItem } from './media'


### PR DESCRIPTION
Adds a wrapper around the `entityService.contentPicker` allowing to pick one or more Content items.

Sample usage:

```js
contentPicker.show({
  multiple: true,
  // invoked when the submit button is clicked
  submit: (items) => {
    console.log(items) // items is an array of objects with an udi property e.g. [{ 'udi': 'umb://document/xxx' }]
  }
})
```
